### PR TITLE
FIX: gcc example uses ndash character where it should use normal dash.

### DIFF
--- a/C/01_dule_color_led/README
+++ b/C/01_dule_color_led/README
@@ -1,2 +1,2 @@
 Run to compile the code.
-	gcc dule_color_led.c –lwiringPi -lpthread
+	gcc dule_color_led.c -lwiringPi -lpthread


### PR DESCRIPTION
The example gcc command given in the README uses the wrong Unicode character, an "ndash" instead of a normal dash. This causes gcc to report "No such file or directory".