### PR TITLE
Add a note about getting the LCD's address

### DIFF
--- a/C/30_i2c_lcd1602/i2c_lcd1602.c
+++ b/C/30_i2c_lcd1602/i2c_lcd1602.c
@@ -3,6 +3,9 @@
 #include <wiringPiI2C.h>
 #include <string.h>
 
+// On the next line, replace 0x27 with the address of your LCD.
+// To get the address, run `i2cdetect -y 1`.
+// For more information, see https://docs.sunfounder.com/projects/sensorkit-v2-pi/en/latest/appendix/i2c_configuration.html
 int LCDAddr = 0x27;
 int BLEN = 1;
 int fd;

--- a/Python/30_i2c_lcd1602.py
+++ b/Python/30_i2c_lcd1602.py
@@ -3,6 +3,9 @@ import LCD1602
 import time
 
 def setup():
+	# On the next line, replace 0x27 with the address of your LCD.
+	# To get the address, run `i2cdetect -y 1`.
+	# For more information, see https://docs.sunfounder.com/projects/sensorkit-v2-pi/en/latest/appendix/i2c_configuration.html
 	LCD1602.init(0x27, 1)	# init(slave address, background light)
 	LCD1602.write(0, 0, 'Greetings!!')
 	LCD1602.write(1, 1, 'from SunFounder')


### PR DESCRIPTION
This note would help people connect to the LCD correctly and not think that their LCDs are defective as in this thread: 
https://forum.sunfounder.com/t/kepler-kit-liquid-crystal-display-error/78/19